### PR TITLE
Add project overview documentation for onboarding

### DIFF
--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -1,0 +1,43 @@
+# Profilo Website Codebase Overview
+
+This repository currently contains the groundwork for building a "Profilo" themed website. At this stage only project scaffolding has been committed, so the codebase is intentionally minimal. This document captures the current structure and the expectations for how the project can evolve so that a newcomer knows where to start contributing.
+
+## Repository layout
+
+```
+profilowebsite/
+├── README.md            # Placeholder README created with the initial commit
+└── docs/
+    └── PROJECT_OVERVIEW.md  # (This file) Introduction to the codebase
+```
+
+Because no application source files have been added yet, the top-level `README.md` still needs to be expanded with information about the project goals, the tech stack, and how to run the site locally. New contributors should plan to flesh this out as implementation work begins.
+
+## Recommended project structure
+
+As development begins, plan to group files into the following top-level folders:
+
+- `src/` – Framework-specific source code (React, Vue, Svelte, Astro, etc.).
+- `public/` – Static assets such as images and fonts.
+- `styles/` – Global CSS, Tailwind configuration, or design tokens if the framework does not co-locate styling with components.
+- `scripts/` – Automation for linting, testing, or deployment pipelines.
+- `docs/` – Long-form documentation like architecture decisions, design briefs, or onboarding guides.
+
+Keeping this structure consistent makes it easier for future maintainers to find related files quickly.
+
+## Key workstreams to prioritize
+
+1. **Define the product vision** – Capture the purpose of the Profilo website, its target audience, and the primary features (e.g., portfolio sections, contact forms, CMS integrations).
+2. **Select the technology stack** – Decide on a front-end framework or static-site generator, CSS methodology, build tooling, and any backend services. Document these choices to help others ramp up quickly.
+3. **Create initial UI wireframes** – Produce low-fidelity sketches or high-fidelity designs to guide implementation. Consider documenting these in the `docs/` directory or linking to an external design system.
+4. **Set up development tooling** – Establish package management (npm/pnpm/yarn), linting (ESLint, Stylelint), formatting (Prettier), and testing (Jest, Vitest, Cypress). Automate checks via GitHub Actions or another CI service when the repository is connected to a remote.
+5. **Draft contribution guidelines** – Expand the `README.md` with instructions for cloning the repo, installing dependencies, running the dev server, and contributing via pull requests.
+
+## Next steps for newcomers
+
+- **Clone and initialize** – Once the stack is chosen, add the required configuration files (`package.json`, framework-specific config) and commit them.
+- **Document architectural decisions** – Use Architecture Decision Records (ADRs) or markdown notes in `docs/` to explain why specific tools or patterns are adopted.
+- **Establish a component library** – If using a component-based framework, plan for a `/components` subdirectory and consider Storybook or similar tooling for UI development.
+- **Plan deployment** – Identify hosting (e.g., Netlify, Vercel, GitHub Pages) and document deployment workflows.
+
+This document should evolve alongside the project. Update it when new directories are added, tooling choices are made, or major features are implemented so that future contributors always have an up-to-date roadmap.


### PR DESCRIPTION
## Summary
- add an onboarding overview in `docs/PROJECT_OVERVIEW.md`
- outline recommended project structure, key workstreams, and next steps for contributors

## Testing
- not applicable (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68deab93c9a4832e9b40c865a8509c01